### PR TITLE
fix: ignore disk_size when disk_autoresize is true

### DIFF
--- a/modules/google_sql_database_instance/main.tf
+++ b/modules/google_sql_database_instance/main.tf
@@ -69,7 +69,7 @@ resource "google_sql_database_instance" "instance" {
     disk_autoresize             = var.settings_disk_autoresize
     disk_autoresize_limit       = var.settings_disk_autoresize_limit
     disk_type                   = var.settings_disk_type
-    disk_size                   = var.settings_disk_autoresize ? null : var.settings_disk_size
+    disk_size                   = var.settings_disk_size
     tier                        = var.settings_tier
 
     backup_configuration {

--- a/modules/google_sql_database_instance/main.tf
+++ b/modules/google_sql_database_instance/main.tf
@@ -69,7 +69,7 @@ resource "google_sql_database_instance" "instance" {
     disk_autoresize             = var.settings_disk_autoresize
     disk_autoresize_limit       = var.settings_disk_autoresize_limit
     disk_type                   = var.settings_disk_type
-    disk_size                   = var.settings_disk_size
+    disk_size                   = var.settings_disk_autoresize ? null : var.settings_disk_size
     tier                        = var.settings_tier
 
     backup_configuration {
@@ -170,7 +170,7 @@ resource "google_sql_database_instance" "read_replica" {
   settings {
 
     tier                        = var.read_replica_settings_tier
-    disk_size                   = var.settings_disk_size
+    disk_size                   = var.settings_disk_autoresize ? null : var.settings_disk_size
     disk_autoresize             = var.settings_disk_autoresize
     disk_type                   = var.settings_disk_type
     deletion_protection_enabled = var.deletion_protection


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Ignore `settings_disk_size` when `settings_disk_autoresize` is set to true to avoid failing to create a read-replica after the master instance has been auto-scaled up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-sql/36)
<!-- Reviewable:end -->
