### PR TITLE
feat: allow GCP services to use private CloudSQL IPs

### DIFF
--- a/modules/google_sql_database_instance/main.tf
+++ b/modules/google_sql_database_instance/main.tf
@@ -94,8 +94,8 @@ resource "google_sql_database_instance" "instance" {
       #tfsec:ignore:google-sql-no-public-access
       ipv4_enabled = var.settings_ip_configuration_ipv4_enabled
 
-      private_network    = var.settings_ip_configuration_private_network
-      allocated_ip_range = var.settings_ip_configuration_allocated_ip_range
+      private_network                               = var.settings_ip_configuration_private_network
+      allocated_ip_range                            = var.settings_ip_configuration_allocated_ip_range
       enable_private_path_for_google_cloud_services = var.settings_ip_configuration_enable_private_path_for_google_cloud_services
     }
 
@@ -195,7 +195,7 @@ resource "google_sql_database_instance" "read_replica" {
       #tfsec:ignore:google-sql-no-public-access
       ipv4_enabled = var.read_replica_settings_ip_configuration_ipv4_enabled
 
-      private_network = var.settings_ip_configuration_private_network
+      private_network                               = var.settings_ip_configuration_private_network
       enable_private_path_for_google_cloud_services = var.settings_ip_configuration_enable_private_path_for_google_cloud_services
     }
 

--- a/modules/google_sql_database_instance/main.tf
+++ b/modules/google_sql_database_instance/main.tf
@@ -96,6 +96,7 @@ resource "google_sql_database_instance" "instance" {
 
       private_network    = var.settings_ip_configuration_private_network
       allocated_ip_range = var.settings_ip_configuration_allocated_ip_range
+      enable_private_path_for_google_cloud_services = var.settings_ip_configuration_enable_private_path_for_google_cloud_services
     }
 
     insights_config {
@@ -195,6 +196,7 @@ resource "google_sql_database_instance" "read_replica" {
       ipv4_enabled = var.read_replica_settings_ip_configuration_ipv4_enabled
 
       private_network = var.settings_ip_configuration_private_network
+      enable_private_path_for_google_cloud_services = var.settings_ip_configuration_enable_private_path_for_google_cloud_services
     }
 
     dynamic "database_flags" {

--- a/modules/google_sql_database_instance/variables.tf
+++ b/modules/google_sql_database_instance/variables.tf
@@ -162,6 +162,12 @@ variable "settings_ip_configuration_allocated_ip_range" {
   default     = ""
 }
 
+variable "settings_ip_configuration_enable_private_path_for_google_cloud_services" {
+  description = "(Optional) Whether Google Cloud services such as BigQuery are allowed to access data in this Cloud SQL instance over a private IP connection. SQLSERVER database type is not supported."
+  type        = string
+  default     = true
+}
+
 variable "settings_database_flags" {
   description = "List of Cloud SQL flags that are applied to the database server. See [more details](https://cloud.google.com/sql/docs/mysql/flags)"
   type        = map(any)


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Added a new variable `enable_private_path_for_google_cloud_services` to the `modules/google_sql_database_instance` module to allow BigQuery to access CloudSQL instances using the private IP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-sql/37)
<!-- Reviewable:end -->
