### PR TITLE
feat: DEVOP-4544| Remove the deprecated attributes from terraform-gcp-sql component module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.91.0 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
+    rev: v1.92.0 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -24,7 +24,7 @@ repos:
       - id: terraform_checkov
         exclude: (test/|examples/)
   - repo: https://github.com/gitguardian/ggshield
-    rev: v1.28.0 # Update to latest version by running `pre-commit autoupdate`
+    rev: v1.29.0 # Update to latest version by running `pre-commit autoupdate`
     hooks:
       - id: ggshield
         language: python

--- a/examples/create_mysql_instance_with_private_ip/main.tf
+++ b/examples/create_mysql_instance_with_private_ip/main.tf
@@ -41,7 +41,7 @@ module "test_sql_database_instance_private_ip" {
   settings_backup_configuration_enabled            = var.settings_backup_configuration_enabled
   settings_ip_configuration_ipv4_enabled           = false
   settings_ip_configuration_private_network        = module.google_compute_network_private_network.id
-  settings_ip_configuration_require_ssl            = var.settings_ip_configuration_require_ssl
+  settings_ip_configuration_ssl_mode               = var.settings_ip_configuration_ssl_mode
   settings_tier                                    = var.settings_tier
   deletion_protection                              = false
 }

--- a/examples/create_mysql_instance_with_private_ip/variables-database-instance.tf
+++ b/examples/create_mysql_instance_with_private_ip/variables-database-instance.tf
@@ -44,8 +44,8 @@ variable "settings_backup_configuration_binary_log_enabled" {
   default     = true
 }
 
-variable "settings_ip_configuration_require_ssl" {
-  description = "(Optional) Whether SSL connections over IP are enforced or not."
-  type        = bool
-  default     = true
+variable "settings_ip_configuration_ssl_mode" {
+  description = " (Optional) Specify how SSL connection should be enforced in DB connections."
+  type        = string
+  default     = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
 }

--- a/examples/create_mysql_instance_with_private_ip/variables.auto.tfvars
+++ b/examples/create_mysql_instance_with_private_ip/variables.auto.tfvars
@@ -12,4 +12,3 @@ settings_disk_size                               = 10
 settings_disk_type                               = "PD_SSD"
 settings_backup_configuration_enabled            = true
 settings_backup_configuration_binary_log_enabled = true
-settings_ip_configuration_require_ssl            = true

--- a/examples/create_mysql_instance_with_public_ip/main.tf
+++ b/examples/create_mysql_instance_with_public_ip/main.tf
@@ -16,7 +16,7 @@ module "test_sql_database_instance" {
   settings_backup_configuration_enabled            = var.settings_backup_configuration_enabled
   settings_ip_configuration_ipv4_enabled           = var.settings_ip_configuration_ipv4_enabled
   settings_ip_configuration_private_network        = var.settings_ip_configuration_private_network
-  settings_ip_configuration_require_ssl            = var.settings_ip_configuration_require_ssl
+  settings_ip_configuration_ssl_mode               = var.settings_ip_configuration_ssl_mode
   settings_tier                                    = var.settings_tier
   deletion_protection                              = false
 }

--- a/examples/create_mysql_instance_with_public_ip/variables-database-instance.tf
+++ b/examples/create_mysql_instance_with_public_ip/variables-database-instance.tf
@@ -50,10 +50,10 @@ variable "settings_backup_configuration_binary_log_enabled" {
   default     = true
 }
 
-variable "settings_ip_configuration_require_ssl" {
-  description = "(Optional) Whether SSL connections over IP are enforced or not."
-  type        = bool
-  default     = true
+variable "settings_ip_configuration_ssl_mode" {
+  description = " (Optional) Specify how SSL connection should be enforced in DB connections."
+  type        = string
+  default     = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
 }
 
 variable "settings_ip_configuration_ipv4_enabled" {

--- a/examples/create_mysql_instance_with_public_ip/variables.auto.tfvars
+++ b/examples/create_mysql_instance_with_public_ip/variables.auto.tfvars
@@ -15,6 +15,5 @@ settings_disk_size                               = 10
 settings_disk_type                               = "PD_SSD"
 settings_backup_configuration_enabled            = true
 settings_backup_configuration_binary_log_enabled = true
-settings_ip_configuration_require_ssl            = true
 settings_ip_configuration_ipv4_enabled           = true
 settings_ip_configuration_private_network        = ""

--- a/examples/mysql_instance_with_read_replica/main.tf
+++ b/examples/mysql_instance_with_read_replica/main.tf
@@ -56,7 +56,7 @@ module "sql_database_instance" {
   settings_ip_configuration_private_network = module.google_compute_network_private_network.id
 
   #checkov:skip=CKV_GCP_6:Ensure all Cloud SQL database instance requires all incoming connections to use SSL"
-  settings_ip_configuration_require_ssl = false
+  settings_ip_configuration_ssl_mode = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
 
   settings_availability_type = var.settings_availability_type
 

--- a/examples/mysql_instance_with_read_replica/variables-database-instance.tf
+++ b/examples/mysql_instance_with_read_replica/variables-database-instance.tf
@@ -44,8 +44,8 @@ variable "settings_backup_configuration_binary_log_enabled" {
   default     = true
 }
 
-variable "settings_ip_configuration_require_ssl" {
-  description = "(Optional) Whether SSL connections over IP are enforced or not."
-  type        = bool
-  default     = true
+variable "settings_ip_configuration_ssl_mode" {
+  description = " (Optional) Specify how SSL connection should be enforced in DB connections."
+  type        = string
+  default     = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
 }

--- a/examples/mysql_instance_with_read_replica/variables.auto.tfvars
+++ b/examples/mysql_instance_with_read_replica/variables.auto.tfvars
@@ -12,4 +12,3 @@ settings_disk_size                               = 10
 settings_disk_type                               = "PD_SSD"
 settings_backup_configuration_enabled            = true
 settings_backup_configuration_binary_log_enabled = true
-settings_ip_configuration_require_ssl            = false

--- a/examples/postgres_instance_with_read_replica/main.tf
+++ b/examples/postgres_instance_with_read_replica/main.tf
@@ -51,7 +51,7 @@ module "sql_database_instance" {
   settings_ip_configuration_private_network = module.google_compute_network_private_network.id
 
   #checkov:skip=CKV_GCP_6:Ensure all Cloud SQL database instance requires all incoming connections to use SSL"
-  settings_ip_configuration_require_ssl = false
+  settings_ip_configuration_ssl_mode = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
 
   settings_availability_type = var.settings_availability_type
 

--- a/examples/postgres_instance_with_read_replica/variables-database-instance.tf
+++ b/examples/postgres_instance_with_read_replica/variables-database-instance.tf
@@ -44,8 +44,8 @@ variable "settings_backup_configuration_binary_log_enabled" {
   default     = true
 }
 
-variable "settings_ip_configuration_require_ssl" {
-  description = "(Optional) Whether SSL connections over IP are enforced or not."
-  type        = bool
-  default     = true
+variable "settings_ip_configuration_ssl_mode" {
+  description = " (Optional) Specify how SSL connection should be enforced in DB connections."
+  type        = string
+  default     = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
 }

--- a/examples/postgres_instance_with_read_replica/variables.auto.tfvars
+++ b/examples/postgres_instance_with_read_replica/variables.auto.tfvars
@@ -12,4 +12,3 @@ settings_disk_size                               = 10
 settings_disk_type                               = "PD_SSD"
 settings_backup_configuration_enabled            = true
 settings_backup_configuration_binary_log_enabled = true
-settings_ip_configuration_require_ssl            = false

--- a/modules/google_service_networking_connection/variables.tf
+++ b/modules/google_service_networking_connection/variables.tf
@@ -15,7 +15,7 @@ variable "reserved_peering_ranges" {
 }
 
 variable "deletion_policy" {
-  description = "(Optional) The deletion policy for the peering. One of 'DELETE' or 'ABANDON'. Defaults to 'DELETE'."
+  description = "(Optional) The deletion policy for the service networking connection. Setting to ABANDON allows the resource to be abandoned rather than deleted. This will enable a successful terraform destroy when destroying CloudSQL instances. Use with care as it can lead to dangling resources."
   type        = string
   default     = ""
 }

--- a/modules/google_sql_database_instance/main.tf
+++ b/modules/google_sql_database_instance/main.tf
@@ -42,6 +42,7 @@ locals {
 #tfsec:ignore:google-sql-pg-log-lock-waits
 #tfsec:ignore:google-sql-pg-log-disconnections
 #tfsec:ignore:google-sql-pg-log-checkpoints
+#tfsec:ignore:google-sql-encrypt-in-transit-data
 resource "google_sql_database_instance" "instance" {
   # This is a component module - these setting will be overridden from the embedding module/repo.
   #checkov:skip=CKV_GCP_51:Ensure PostgreSQL database 'log_checkpoints' flag is set to 'on'
@@ -54,7 +55,8 @@ resource "google_sql_database_instance" "instance" {
   #checkov:skip=CKV_GCP_111:Ensure GCP PostgreSQL logs SQL statements 'pgaudit.log' flag is set to 'all'
   #checkov:skip=CKV2_GCP_20:Ensure MySQL DB instance has point-in-time recovery backup configured
   #checkov:skip=CKV2_GCP_13:Ensure PostgreSQL database flag 'log_duration' is set to 'on'
-  #checkov:skip=CKV_GCP_79: "Ensure SQL database is using latest Major version"
+  #checkov:skip=CKV_GCP_79:Ensure SQL database is using latest Major version
+  #checkov:skip=CKV_GCP_6:Ensure all Cloud SQL database instance requires all incoming connections to use SSL
 
   database_version = var.database_version
 
@@ -88,10 +90,10 @@ resource "google_sql_database_instance" "instance" {
 
     ip_configuration {
       #tfsec:ignore:google-sql-encrypt-in-transit-data
-      require_ssl = var.settings_ip_configuration_require_ssl
+      ssl_mode = var.settings_ip_configuration_ssl_mode
 
       #checkov:skip=CKV_GCP_60:Ensure Cloud SQL database does not have public IP - default value is false
-      #tfsec:ignore:google-sql-no-public-access
+      #tfsec:ignore:google-sql-no-public-access:Ensure Cloud SQL database does not have public IP
       ipv4_enabled = var.settings_ip_configuration_ipv4_enabled
 
       private_network                               = var.settings_ip_configuration_private_network
@@ -153,7 +155,8 @@ resource "google_sql_database_instance" "read_replica" {
   #checkov:skip=CKV_GCP_111:Ensure GCP PostgreSQL logs SQL statements 'pgaudit.log' flag is set to 'all'
   #checkov:skip=CKV2_GCP_20:Ensure MySQL DB instance has point-in-time recovery backup configured
   #checkov:skip=CKV2_GCP_13:Ensure PostgreSQL database flag 'log_duration' is set to 'on'
-  #checkov:skip=CKV_GCP_79: "Ensure SQL database is using latest Major version"
+  #checkov:skip=CKV_GCP_79:Ensure SQL database is using latest Major version
+  #checkov:skip=CKV_GCP_6:Ensure all Cloud SQL database instance requires all incoming connections to use SSL
 
   depends_on = [
     google_sql_database_instance.instance
@@ -182,17 +185,16 @@ resource "google_sql_database_instance" "read_replica" {
     disk_autoresize_limit = var.settings_disk_autoresize_limit
 
     backup_configuration {
-      #tfsec:ignore:google-sql-enable-backup:read replica no need to backup
       enabled            = false
       binary_log_enabled = false
     }
 
     ip_configuration {
-      #tfsec:ignore:google-sql-encrypt-in-transit-data:because default value is true
-      require_ssl = var.settings_ip_configuration_require_ssl
+      #tfsec:ignore:google-sql-encrypt-in-transit-data
+      ssl_mode = var.settings_ip_configuration_ssl_mode
 
       #checkov:skip=CKV_GCP_60:Ensure Cloud SQL database does not have public IP - default value is false
-      #tfsec:ignore:google-sql-no-public-access
+      #tfsec:ignore:google-sql-no-public-access: "Ensure Cloud SQL database does not have public IP"
       ipv4_enabled = var.read_replica_settings_ip_configuration_ipv4_enabled
 
       private_network                               = var.settings_ip_configuration_private_network

--- a/modules/google_sql_database_instance/variables.tf
+++ b/modules/google_sql_database_instance/variables.tf
@@ -132,10 +132,14 @@ variable "settings_backup_configuration_backup_retention_settings_retained_backu
   default     = 7
 }
 
-variable "settings_ip_configuration_require_ssl" {
-  description = "(Optional) Whether SSL connections over IP are enforced or not."
-  type        = bool
-  default     = true
+variable "settings_ip_configuration_ssl_mode" {
+  description = "(Optional) Specify how SSL connection should be enforced in DB connections. Supported values are `ALLOW_UNENCRYPTED_AND_ENCRYPTED`, `ENCRYPTED_ONLY`, `TRUSTED_CLIENT_CERTIFICATE_REQUIRED`."
+  type        = string
+  default     = "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+  validation {
+    condition     = can(regex("ALLOW_UNENCRYPTED_AND_ENCRYPTED|ENCRYPTED_ONLY|TRUSTED_CLIENT_CERTIFICATE_REQUIRED", var.settings_ip_configuration_ssl_mode))
+    error_message = "Support only `ALLOW_UNENCRYPTED_AND_ENCRYPTED`, `ENCRYPTED_ONLY`, `TRUSTED_CLIENT_CERTIFICATE_REQUIRED`."
+  }
 }
 
 variable "settings_ip_configuration_ipv4_enabled" {


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

*The require_ssl attribute will be deprecated in future versions of the GCP provider. Currently, it generates a warning when running the api-storage-infrastructure Terraform workspace. To address this issue, we need to use the ssl_mode attribute instead.

## How This is Backward Compatible:
The ssl_mode attribute specifies how SSL/TLS is enforced in database connections. For backward compatibility, the following value pairs for ssl_mode and require_ssl are valid:
```

For PostgreSQL and MySQL:
sslMode=ALLOW_UNENCRYPTED_AND_ENCRYPTED and requireSsl=false
sslMode=ENCRYPTED_ONLY and requireSsl=false
sslMode=TRUSTED_CLIENT_CERTIFICATE_REQUIRED and requireSsl=true
```


<!-- WRITE A SHORT DESCRIPTION OF CHANGES -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-sql/45)
<!-- Reviewable:end -->
