### PR TITLE
feat: support PSC for CloudSql read replicas [MLOPS-8283]

### DIFF
--- a/modules/google_sql_database_instance/main.tf
+++ b/modules/google_sql_database_instance/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.48, < 7.0"
+      version = ">= 6.0, < 7.0"
     }
   }
 }
@@ -207,6 +207,18 @@ resource "google_sql_database_instance" "read_replica" {
 
       private_network                               = var.settings_ip_configuration_private_network
       enable_private_path_for_google_cloud_services = var.settings_ip_configuration_enable_private_path_for_google_cloud_services
+
+      dynamic "psc_config" {
+        for_each = var.read_replica_psc_config == null ? [] : [var.read_replica_psc_config]
+        content {
+          psc_enabled = coalesce(
+            psc_config.value.psc_enabled,
+            true
+          )
+
+          allowed_consumer_projects = psc_config.value.allowed_consumer_projects
+        }
+      }
     }
 
     insights_config {

--- a/modules/google_sql_database_instance/variables.tf
+++ b/modules/google_sql_database_instance/variables.tf
@@ -246,3 +246,12 @@ variable "edition" {
     error_message = "edition must be one of: ENTERPRISE or ENTERPRISE_PLUS."
   }
 }
+
+variable "read_replica_psc_config" {
+  description = "(Optional) PSC config for read replicas"
+  type = object({
+    psc_enabled               = optional(bool)
+    allowed_consumer_projects = optional(set(string))
+  })
+  default = null
+}


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

### Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.
- [ ] All entities that I am working with are up-to-date in Backstage; if updates are needed, I have linked the relevant PRs. [Backstage guide](https://www.notion.so/honestbank/How-to-Write-a-Backstage-Service-Catalog-Entry-a-catalog-info-yaml-file-21845ff72e404b14aed2ac989fb202cf?pvs=4)

### Description

* Support Private Service Connect for CloudSQL read replicas.
* Needed for reading `core-api` from Chalk - Chalk is in a peered VPC and VPC peering doesn't support transitive routing.
* Set the minimum Google provider to 6. Currently we are using 6.x.x. in [api-storage-infrastructure](https://github.com/honestbank/api-storage-infrastructure/blob/5c560f3e7624174c8570f1d1e8aaed605f1d9b3a/remote_backend.tf#L11). PSC is not supported in  4.x.x.

