### PR TITLE
feat: remove unused GOOGLE_CREDENTIALS_READ_ALL_PROJECTS from workflow [SEC-549]

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,7 +11,6 @@ on:
 env:
   tf_version: "latest"
   tf_working_dir: "."
-  GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS_READ_ALL_PROJECTS }}
 jobs:
   terraform:
     name: "terraform"


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

### Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.
- [ ] All entities that I am working with are up-to-date in Backstage; if updates are needed, I have linked the relevant PRs. [Backstage guide](https://www.notion.so/honestbank/How-to-Write-a-Backstage-Service-Catalog-Entry-a-catalog-info-yaml-file-21845ff72e404b14aed2ac989fb202cf?pvs=4)

### Description

**What**: Removed `GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS_READ_ALL_PROJECTS }}` from the top-level `env:` block in `.github/workflows/terraform.yml`.

**Why**: This is a Terraform module repo — there is no root-level `providers.tf` with a `credentials` block, and no backend configuration at the root. The `GOOGLE_CREDENTIALS` environment variable has nothing to authenticate to at the root module level. Exposing the secret unnecessarily increases the blast radius if the workflow is ever compromised. This is part of the SEC-549 / SEC-515 post-Trivy secret hygiene cleanup.

**Verification**: If the credential were actually needed (e.g. for `terraform init` or `terraform validate`), the existing `terraform validate` step in the CI workflow would fail, providing a built-in regression guard.

Relates to SEC-549.